### PR TITLE
Update black to 18.6b4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description_content_type="text/markdown",
     py_modules=["pytest_black"],
     python_requires=">=3.6",
-    install_requires=["pytest>=3.5.0", "black==18.6b2"],
+    install_requires=["pytest>=3.5.0", "black>=18.6b4"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Pytest",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 ignore = E501
 
 [tox]
-envlist = py36,flake8
+envlist = py36,py37,flake8
 
 [testenv]
 deps = pytest>=3.0


### PR DESCRIPTION
Also adds the `py37` environment to our list of tox test environments.