### PR TITLE
Skip repeated tests if the file's mtime hasn't changed

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -33,3 +33,31 @@ def test_pass(testdir):
 
     result = testdir.runpytest("--black")
     result.assert_outcomes(passed=1)
+
+
+def test_mtime_cache(testdir):
+    """Assert test is skipped when file hasn't changed
+    """
+    p = testdir.makepyfile(
+        """
+        def hello():
+            print("Hello, world!")
+    """
+    )
+    # replace trailing newline (stripped by testdir.makepyfile)
+    contents = p.read() + "\n"
+    p.write(contents)
+
+    # Test once to populate the cache
+    result = testdir.runpytest("--black")
+    result.assert_outcomes(passed=1)
+
+    # Run it again, it should be skipped
+    result = testdir.runpytest("--black", "-rs")
+    result.assert_outcomes(skipped=1)
+    result.stdout.fnmatch_lines(["SKIP * previously passed black format checks"])
+
+    # Update the file and test again.
+    p.write(contents)
+    result = testdir.runpytest("--black")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
On a large codebase, starting a black subprocess per file can be quite slow. We can speed test runs up by caching the modification time of each file when it passes the black format test, and skipping subsequent tests until the modification time changes.

The mtimes are stored in pytest's cache. The implementation is based on the equivalent feature in pytest-flake8:

https://github.com/tholo/pytest-flake8/blob/master/pytest_flake8.py
