### PR TITLE
Parse pyproject.toml and apply include/exclude options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ $ pytest --black
 The plugin will output a diff of suggested formatting changes (if any exist). Changes will _not_ be applied automatically.
 
 
+Configuration
+-------------
+
+You can override default black configuration options by placing a `pyproject.toml` file in your project directory. See example configuration [here](https://github.com/ambv/black/blob/master/pyproject.toml).
+
 Testing
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name="pytest-black",
-    version="0.3.0",
+    version="0.3.1",
     author="ShopKeep Inc",
     author_email="oss@shopkeep.com",
     maintainer="ShopKeep Inc",


### PR DESCRIPTION
Parses `pyproject.toml` and applies black include / exclude options.