### PR TITLE
Use black as Python module instead of executable

### DIFF
--- a/pytest_black.py
+++ b/pytest_black.py
@@ -3,6 +3,7 @@
 # stdlib imports
 import subprocess
 import re
+import sys
 
 # third-party imports
 import pytest
@@ -59,7 +60,7 @@ class BlackItem(pytest.Item, pytest.File):
             pytest.skip("file(s) excluded by pyproject.toml")
 
     def runtest(self):
-        cmd = ["black", "--check", "--diff", "--quiet", str(self.fspath)]
+        cmd = [sys.executable, "-m", "black", "--check", "--diff", "--quiet", str(self.fspath)]
         try:
             subprocess.run(
                 cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True


### PR DESCRIPTION
I ran into the same issue as @maxbrunet in #20, trying to use `pytest-black` along with `pytest` in my setuptools' `tests_require`, but without a typical global install of `black`. 

This change is more minimal than #21, which might make it more resilient (at least, more in line with how `black` wants to be run). They're complementary, so if you merge that one (which is probably going to be faster), please close this one.