### PR TITLE
Fix broken tests

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -55,7 +55,7 @@ def test_mtime_cache(testdir):
     # Run it again, it should be skipped
     result = testdir.runpytest("--black", "-rs")
     result.assert_outcomes(skipped=1)
-    result.stdout.fnmatch_lines(["SKIP * previously passed black format checks"])
+    result.stdout.fnmatch_lines(["SKIP*previously passed black format checks"])
 
     # Update the file and test again.
     p.write(contents)


### PR DESCRIPTION
Travis builds have been failing since https://travis-ci.org/shopkeep/pytest-black/builds/487047293. This was the first test run after the release of pytest 4.2.0 and there was a change in behaviour.

This didn't affect operation of the plugin, one of the tests could no longer verify that a test had been skipped.