### PR TITLE
Use setuptools_scm to extract version number from git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ def read(fname):
 
 setup(
     name="pytest-black",
-    version="0.3.3",
     author="ShopKeep Inc",
     author_email="oss@shopkeep.com",
     maintainer="ShopKeep Inc",
@@ -26,6 +25,8 @@ setup(
     py_modules=["pytest_black"],
     python_requires=">=3.6",
     install_requires=["pytest>=3.5.0", "black==18.9b0"],
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Pytest",


### PR DESCRIPTION
[setuptools_scm](https://github.com/pypa/setuptools_scm/) allows us to generate a version number from git metadata instead of hardcoding a value in `setup.py`.

This means it is no longer necessary to bump the version number prior to making a new release. Just tag it.

TODO:

- [x] Rebase on master once #25 is merged