### PR TITLE
Upgrade black version to latest (19.3b0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description_content_type="text/markdown",
     py_modules=["pytest_black"],
     python_requires=">=3.6",
-    install_requires=["pytest>=3.5.0", "black==18.9b0"],
+    install_requires=["pytest>=3.5.0", "black==19.3b0"],
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     classifiers=[


### PR DESCRIPTION
`black==19.3b0` was released on 2019-03-14

See:
* https://black.readthedocs.io/en/stable/change_log.html
* https://pypi.org/project/black/#history

Fixes #27 
