### PR TITLE
Stop relying on specific versions of black

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description_content_type="text/markdown",
     py_modules=["pytest_black"],
     python_requires=">=3.6",
-    install_requires=["pytest>=3.5.0", "black==19.3b0"],
+    install_requires=["pytest>=3.5.0", "black"],
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     classifiers=[


### PR DESCRIPTION
As far as I can see there is little point in pinning a specific version of black here. This causes dependency issues if you rely on a slightly older version, and it also means you have to keep updating this package.

This library does not use any black internals, it just runs `python -m black ...`, so this should be safe to do.