### PR TITLE
fix: address PytestUnknownMarkWarning

### DIFF
--- a/pytest_black.py
+++ b/pytest_black.py
@@ -30,6 +30,7 @@ def pytest_configure(config):
     # load cached mtimes at session startup
     if config.option.black and hasattr(config, "cache"):
         config._blackmtimes = config.cache.get(HISTKEY, {})
+    config.addinivalue_line("markers", "black: enable format checking with black")
 
 
 def pytest_unconfigure(config):

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -116,3 +116,21 @@ def test_include(testdir):
 
     result = testdir.runpytest("--black")
     result.assert_outcomes(skipped=0, passed=1)
+
+
+def test_pytest_deprecation_warning(testdir):
+    """Assert no deprecation warning is raised during test."""
+    p = testdir.makepyfile(
+        """
+        def hello():
+            print("Hello, world!")
+    """
+    )
+    # replace trailing newline (stripped by testdir.makepyfile)
+    p = p.write(p.read() + "\n")
+
+    result = testdir.runpytest("--black")
+    result.assert_outcomes(passed=1)
+
+    out = "\n".join(result.stdout.lines)
+    assert "PytestUnknownMarkWarning" not in out


### PR DESCRIPTION
As of pytest 4.5.0, a new warning is raised when the plugin doesn't
register its markers. See pytest-dev/pytest#5177

The docs recommend registering custom markers:
https://docs.pytest.org/en/latest/writing_plugins.html#registering-markers

Signed-off-by: Mike Fiedler <miketheman@gmail.com>