### PR TITLE
Remove upperbound for required black version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     python_requires=">=2.7",
     install_requires=[
         "pytest>=3.5.0",
-        'black==19.3b0; python_version >= "3.6"',
+        'black>=19.3b0; python_version >= "3.6"',
         "toml",
     ],
     use_scm_version=True,


### PR DESCRIPTION
As long as there is no reason to restrict the black version I think it should not be pinned