### PR TITLE
Remove black version number to fix pipenv bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Requirements
 * [pytest](https://docs.pytest.org/en/latest/)
 * [black](https://github.com/ambv/black)
 
+There is a minimum requirement of black 19.3b0 or later.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setup(
     python_requires=">=2.7",
     install_requires=[
         "pytest>=3.5.0",
-        'black>=19.3b0; python_version >= "3.6"',
+        # Minimum requirement on black 19.3b0 or later is not declared here as
+        # workaround for https://github.com/pypa/pipenv/issues/3928
+        'black; python_version >= "3.6"',
         "toml",
     ],
     use_scm_version=True,


### PR DESCRIPTION
At the moment a Pipfile like this:
```
[[source]]
url = "https://pypi.org/simple"
verify_ssl = true
name = "pypi"

[dev-packages]
"black" = "==19.10b0"
"pytest-black" = "*"

[pipenv]
allow_prereleases = false
```

Fails with:
```
$ pipenv install --dev
...
ERROR: ERROR: Could not find a version that matches black==19.10b0,>=19.3b0
Skipped pre-versions: 19.3b0, 19.10b0, 19.10b0
```
This PR removes the version requirement on black so that the above Pipfile would work.
Mentioned in #38 and solution from https://github.com/peterjc/flake8-black/pull/22