### PR TITLE
implement collect

### DIFF
--- a/pytest_black.py
+++ b/pytest_black.py
@@ -107,6 +107,12 @@ class BlackItem(pytest.Item, pytest.File):
             regex = "(?x)" + regex
         return re.compile(regex)
 
+    def collect(self):
+        """ returns a list of children (items and collectors)
+            for this collection node.
+        """
+        return (self,)
+
 
 class BlackError(Exception):
     pass


### PR DESCRIPTION
Implement collect (from BlackItem <- pytest.File <- pytest.FSCollector <- pytest.Collector).
This is only called by pytest when an `__init__.py` file is given as argument, e.g.

```
$ pytest --black my_package/__init__.py
```

Current behaviour:
```
$ pytest --black my_repo/__init__.py
=============================== test session starts ================================
platform linux -- Python 3.8.0, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /path/to/my_repo, configfile: pyproject.toml
plugins: black-0.3.11
collected 0 items / 1 error                                                        

====================================== ERRORS ======================================
__________________________ ERROR collecting test session ___________________________
.venv/lib/python3.8/site-packages/_pytest/runner.py:294: in from_call
    result = func()  # type: Optional[_T]
.venv/lib/python3.8/site-packages/_pytest/runner.py:324: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
.venv/lib/python3.8/site-packages/_pytest/main.py:576: in collect
    yield from self._collect(fspath, parts)
.venv/lib/python3.8/site-packages/_pytest/main.py:662: in _collect
    yield next(iter(m[0].collect()))
.venv/lib/python3.8/site-packages/_pytest/nodes.py:457: in collect
    raise NotImplementedError("abstract")
E   NotImplementedError: abstract
============================= short test summary info ==============================
ERROR  - NotImplementedError: abstract
!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!
================================= 1 error in 0.12s =================================
```

also see
- pytest-flakes https://github.com/asmeurer/pytest-flakes/pull/38