### PR TITLE
fix pytest.Testdir.makefile call

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -72,8 +72,8 @@ def test_exclude(testdir):
     """Assert test is skipped if path is excluded even if also included
     """
     testdir.makefile(
-        "pyproject.toml",
-        """
+        ".toml",
+        pyproject = """
         [tool.black]
             include = 'test_exclude.py'
             exclude = '.*'
@@ -100,8 +100,8 @@ def test_exclude_folder(testdir):
     """Assert test is skipped for files in a folder
     """
     testdir.makefile(
-        "pyproject.toml",
-        """
+        ".toml",
+        pyproject = """
         [tool.black]
             exclude = '''
             (
@@ -137,8 +137,8 @@ def test_include(testdir):
     """Assert test is not skipped if path is included but not excluded
     """
     testdir.makefile(
-        "pyproject.toml",
-        """
+        ".toml",
+        pyproject = """
         [tool.black]
             include = 'test_include'
     """,


### PR DESCRIPTION
abusing the ext parameter of `Testdir.makefile` for the full filename does not work with pytest 6.

https://docs.pytest.org/en/stable/reference.html#pytest.Pytester.makefile
AFAICT the correct call signature has always been like that: https://docs.pytest.org/en/4.6.x/reference.html#_pytest.pytester.Testdir.makefile