### PR TITLE
fix(tests): Updates pytest fixture and Path uses - no functional change

### DIFF
--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -6,101 +6,99 @@ import pytest
 pytestmark = pytest.mark.usefixtures('black_available')
 
 
-def test_help_message(testdir):
-    result = testdir.runpytest("--help")
+def test_help_message(pytester):
+    result = pytester.runpytest("--help")
     result.stdout.fnmatch_lines(["*--black*enable format checking with black"])
 
 
-def test_fail(testdir):
+def test_fail(pytester):
     """Assert test fails due to single quoted strings
     """
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         def hello():
             print('Hello, world')
     """
     )
-    result = testdir.runpytest("--black")
+    result = pytester.runpytest("--black")
     result.assert_outcomes(failed=1)
 
 
-def test_pass(testdir):
+def test_pass(pytester):
     """Assert test passes when no formatting issues are found
     """
-    p = testdir.makepyfile(
+    p = pytester.makepyfile(
         """
         def hello():
             print("Hello, world!")
     """
     )
-    # replace trailing newline (stripped by testdir.makepyfile)
-    p = p.write(p.read() + "\n")
+    # replace trailing newline (stripped by pytester.makepyfile)
+    p = p.write_text(p.read_text() + "\n")
 
-    result = testdir.runpytest("--black")
+    result = pytester.runpytest("--black")
     result.assert_outcomes(passed=1)
 
 
-def test_mtime_cache(testdir):
+def test_mtime_cache(pytester):
     """Assert test is skipped when file hasn't changed
     """
-    p = testdir.makepyfile(
+    p = pytester.makepyfile(
         """
         def hello():
             print("Hello, world!")
     """
     )
-    # replace trailing newline (stripped by testdir.makepyfile)
-    contents = p.read() + "\n"
-    p.write(contents)
+    # replace trailing newline (stripped by pytester.makepyfile)
+    contents = p.read_text() + "\n"
+    p.write_text(contents)
 
     # Test once to populate the cache
-    result = testdir.runpytest("--black")
+    result = pytester.runpytest("--black")
     result.assert_outcomes(passed=1)
 
     # Run it again, it should be skipped
-    result = testdir.runpytest("--black", "-rs")
+    result = pytester.runpytest("--black", "-rs")
     result.assert_outcomes(skipped=1)
     result.stdout.fnmatch_lines(["SKIP*previously passed black format checks"])
 
     # Update the file and test again.
-    p.write(contents)
-    result = testdir.runpytest("--black")
+    p.write_text(contents)
+    result = pytester.runpytest("--black")
     result.assert_outcomes(passed=1)
 
 
-def test_exclude(testdir):
+def test_exclude(pytester):
     """Assert test is skipped if path is excluded even if also included
     """
-    testdir.makefile(
-        "pyproject.toml",
+    pytester.makepyprojecttoml(
         """
         [tool.black]
             include = 'test_exclude.py'
             exclude = '.*'
     """,
     )
-    p = testdir.makepyfile(
+    p = pytester.makepyfile(
         """
         def hello():
             print("Hello, world!")
     """
     )
 
-    # replace trailing newline (stripped by testdir.makepyfile)
-    p = p.write(p.read() + "\n")
+    # replace trailing newline (stripped by pytester.makepyfile)
+    p = p.write_text(p.read_text() + "\n")
 
     # Rename pyproject.toml ¯\_(ツ)_/¯
-    testdir.run("mv", "test_exclude.pyproject.toml", "pyproject.toml")
+    pytester.run("mv", "test_exclude.pyproject.toml", "pyproject.toml")
 
-    result = testdir.runpytest("--black")
+    result = pytester.runpytest("--black")
     result.assert_outcomes(skipped=1, passed=0)
 
 
-def test_exclude_folder(testdir):
+def test_exclude_folder(pytester):
     """Assert test is skipped for files in a folder
     """
-    testdir.makefile(
-        "pyproject.toml",
+    pytester.makepyprojecttoml(
         """
         [tool.black]
             exclude = '''
@@ -113,65 +111,64 @@ def test_exclude_folder(testdir):
     '''
     """,
     )
-    p = testdir.makepyfile(
+    p = pytester.makepyfile(
         """
         def hello():
             print("Hello, world!")
     """
     )
-    # replace trailing newline (stripped by testdir.makepyfile)
-    p = p.write(p.read() + "\n")
+    # replace trailing newline (stripped by pytester.makepyfile)
+    p = p.write_text(p.read_text() + "\n")
 
     # Move file into folder that should be excluded
-    ignore_folder = testdir.mkdir("ignore_folder")
-    testdir.run("mv", "test_exclude_folder.py", ignore_folder)
+    ignore_folder = pytester.mkdir("ignore_folder")
+    pytester.run("mv", "test_exclude_folder.py", ignore_folder)
 
     # Rename pyproject.toml ¯\_(ツ)_/¯
-    testdir.run("mv", "test_exclude_folder.pyproject.toml", "pyproject.toml")
+    pytester.run("mv", "test_exclude_folder.pyproject.toml", "pyproject.toml")
 
-    result = testdir.runpytest("--black")
+    result = pytester.runpytest("--black")
     result.assert_outcomes(skipped=1, passed=0)
 
 
-def test_include(testdir):
+def test_include(pytester):
     """Assert test is not skipped if path is included but not excluded
     """
-    testdir.makefile(
-        "pyproject.toml",
+    pytester.makepyprojecttoml(
         """
         [tool.black]
             include = 'test_include'
     """,
     )
-    p = testdir.makepyfile(
+    p = pytester.makepyfile(
         """
         def hello():
             print("Hello, world!")
     """
     )
 
-    # replace trailing newline (stripped by testdir.makepyfile)
-    p = p.write(p.read() + "\n")
+    # replace trailing newline (stripped by pytester.makepyfile)
+    p = p.write_text(p.read_text() + "\n")
 
     # Rename pyproject.toml ¯\_(ツ)_/¯
-    testdir.run("mv", "test_include.pyproject.toml", "pyproject.toml")
+    pytester.run("mv", "test_include.pyproject.toml", "pyproject.toml")
 
-    result = testdir.runpytest("--black")
+    result = pytester.runpytest("--black")
     result.assert_outcomes(skipped=0, passed=1)
 
 
-def test_pytest_deprecation_warning(testdir):
+def test_pytest_deprecation_warning(pytester):
     """Assert no deprecation warning is raised during test."""
-    p = testdir.makepyfile(
+    p = pytester.makepyfile(
         """
         def hello():
             print("Hello, world!")
     """
     )
-    # replace trailing newline (stripped by testdir.makepyfile)
-    p = p.write(p.read() + "\n")
+    # replace trailing newline (stripped by pytester.makepyfile)
+    p = p.write_text(p.read_text() + "\n")
 
-    result = testdir.runpytest("--black")
+    result = pytester.runpytest("--black")
     result.assert_outcomes(passed=1)
 
     out = "\n".join(result.stdout.lines)


### PR DESCRIPTION
Here we update API calls to use the latest reccomended:
 * all 'testdir' fixtures now use the prefered 'pytester' fixture (the
   same in all usecases for pytest-black).
 * all 'Path.write' uses now use the more explicit `Path.write_text' api
   instead.
 * we replace `makefile("pyproject.toml", ...` with `makepyprojecttoml(`
   which is clearly defined just for this usecase.

There should be no functional change with this patch, except that older
python versions are probably no longer supported.